### PR TITLE
Remove explanation that is not exits, in Help

### DIFF
--- a/jscoverage-help.txt
+++ b/jscoverage-help.txt
@@ -5,7 +5,6 @@ Options:
       --encoding=ENCODING   assume .js files use the given character encoding
       --exclude=PATH        do not copy PATH
       --js-version=VERSION  use the specified JavaScript version
-      --no-highlight        do not perform syntax highlighting
       --no-instrument=PATH  copy but do not instrument PATH
   -v, --verbose             explain what is being done
   -h, --help                display this help and exit


### PR DESCRIPTION
"--no-highlight" is not exits now.
