### PR TITLE
Fix installation guide

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-    $ ./configure && make install
+    $ ./configure && make && make install
 
   or
 


### PR DESCRIPTION
Instructions for user to compile missing `make` step, this commit adds that. (Looks like this caused some confusion in #8)
