### PR TITLE
Missing 'make' command from installation instructions in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-    $ ./configure && make install
+    $ ./configure && make && make install
 
   Warning: the `jscoverage` npm module published
   by someone else does _not_ work, clone this repo.


### PR DESCRIPTION
If you omit the 'make' command before 'make install' it fails (at least on OSX).
I left the npm warning intact (I noticed another pull request with a similar correction).
