### PR TITLE
Handling multiple files of the same name

### DIFF
--- a/instrument.c
+++ b/instrument.c
@@ -216,9 +216,16 @@ void jscoverage_instrument(const char * source,
       free(ni);
     }
 
-    int length = strlen(path) + strlen(p->name) + 1;
+    /** make sure the path does not end in a slash. **/
+    size_t length;
+    while (string_ends_with(path, "/")) {
+        length = strlen(path);
+        path[length-1] = '\0';
+    }
+
+    length = strlen(path) + strlen(p->name) + 1;
     char * filepath = malloc(length);
-    sprintf(filepath, "%s/%s", path, p->name);
+    snprintf(filepath, length, "%s/%s", path, p->name);
     instrument_file(s, d, p->name, instrument_this, filepath);
 
   cleanup:

--- a/instrument.c
+++ b/instrument.c
@@ -70,7 +70,7 @@ static void check_contains_file(const char * file1, const char * file2) {
   }
 }
 
-static void instrument_file(const char * source_file, const char * destination_file, const char * id, int instrumenting) {
+static void instrument_file(const char * source_file, const char * destination_file, const char * id, int instrumenting, char * filepath) {
   if (g_verbose) {
     printf("Instrumenting file %s\n", id);
   }
@@ -108,7 +108,7 @@ static void instrument_file(const char * source_file, const char * destination_f
         else if (result == JSCOVERAGE_ERROR_INVALID_BYTE_SEQUENCE) {
           fatal("error decoding %s in file %s", jscoverage_encoding, id);
         }
-        jscoverage_instrument_js(id, characters, num_characters, output_stream);
+        jscoverage_instrument_js(filepath, characters, num_characters, output_stream);
         free(characters);
 
         if (fwrite(output_stream->data, 1, output_stream->length, output) != output_stream->length) {
@@ -135,7 +135,8 @@ void jscoverage_instrument(const char * source,
                            char ** exclude,
                            int num_exclude,
                            char ** no_instrument,
-                           int num_no_instrument)
+                           int num_no_instrument,
+                           char * path)
 {
   assert(source != NULL);
   assert(destination != NULL);
@@ -215,9 +216,13 @@ void jscoverage_instrument(const char * source,
       free(ni);
     }
 
-    instrument_file(s, d, p->name, instrument_this);
+    int length = strlen(path) + strlen(p->name) + 1;
+    char * filepath = malloc(length);
+    sprintf(filepath, "%s/%s", path, p->name);
+    instrument_file(s, d, p->name, instrument_this, filepath);
 
   cleanup:
+    free(filepath);
     free(s);
     free(d);
   }

--- a/instrument.c
+++ b/instrument.c
@@ -223,7 +223,7 @@ void jscoverage_instrument(const char * source,
         path[length-1] = '\0';
     }
 
-    length = strlen(path) + strlen(p->name) + 1;
+    length = strlen(path) + strlen(p->name) + 2;
     char * filepath = malloc(length);
     snprintf(filepath, length, "%s/%s", path, p->name);
     instrument_file(s, d, p->name, instrument_this, filepath);

--- a/instrument.h
+++ b/instrument.h
@@ -26,6 +26,7 @@ void jscoverage_instrument(const char * source,
                            char ** exclude,
                            int num_exclude,
                            char ** no_instrument,
-                           int num_no_instrument);
+                           int num_no_instrument,
+                           const char * path);
 
 #endif /* INSTRUMENT_H_ */

--- a/instrument.h
+++ b/instrument.h
@@ -27,6 +27,6 @@ void jscoverage_instrument(const char * source,
                            int num_exclude,
                            char ** no_instrument,
                            int num_no_instrument,
-                           const char * path);
+                           char * path);
 
 #endif /* INSTRUMENT_H_ */

--- a/jscoverage.c
+++ b/jscoverage.c
@@ -126,7 +126,8 @@ int main(int argc, char ** argv) {
     fatal_command_line("missing argument");
   }
 
-  char * path = strdup(source);
+  char * path;
+  path = strdup(source);
   source = make_canonical_path(source);
   destination = make_canonical_path(destination);
 

--- a/jscoverage.c
+++ b/jscoverage.c
@@ -126,17 +126,19 @@ int main(int argc, char ** argv) {
     fatal_command_line("missing argument");
   }
 
+  char * path = strdup(source);
   source = make_canonical_path(source);
   destination = make_canonical_path(destination);
 
   jscoverage_init();
-  jscoverage_instrument(source, destination, verbose, exclude, num_exclude, no_instrument, num_no_instrument);
+  jscoverage_instrument(source, destination, verbose, exclude, num_exclude, no_instrument, num_no_instrument, path);
   jscoverage_cleanup();
 
   free(source);
   free(destination);
   free(exclude);
   free(no_instrument);
+  free(path);
 
   exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
If your directory structure is nested, and contains multiple files of the same name, the coverage output gets clobbered. 

Thus, if your structure looked like this:

```
/project/fixtures/Policy.js
/project/lib/Policy.js
```

previously you would only see coverage for one of these two files.  With this change, the coverage for both files will be shown.

Interestingly, the CSS already accounted for this by colouring the path grey and the filename white, but the jscoverage output did not.

This fixes the problem.
