### PR TITLE
Remove --syntax-highlighting from help text

### DIFF
--- a/jscoverage-help.txt
+++ b/jscoverage-help.txt
@@ -5,7 +5,6 @@ Options:
       --encoding=ENCODING   assume .js files use the given character encoding
       --exclude=PATH        do not copy PATH
       --js-version=VERSION  use the specified JavaScript version
-      --no-highlight        do not perform syntax highlighting
       --no-instrument=PATH  copy but do not instrument PATH
   -v, --verbose             explain what is being done
   -h, --help                display this help and exit


### PR DESCRIPTION
Since 36b7050a93c2cd4980a96a5a735bee6690ffba81 prevented highlighting, I believe the help text should not have the option anymore.
